### PR TITLE
Use global regex to replace spaces in header

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var host = '0.0.0.0';
-var port = 80;
+var port = 8000;
 
 var _ = require('lodash');
 var bunyan = require('bunyan');
@@ -44,7 +44,7 @@ app.all('*', function (req, res, next) {
 
     // Injects X-Mirror-* headers to response headers
     reqHeaders.forEach(function (name) {
-        var resHeader = _.startCase(_.trimStart(name, 'x-mirror-')).replace(' ', '-');
+        var resHeader = _.startCase(_.trimStart(name, 'x-mirror-')).replace(/ /g, '-');
         responseHeaders[resHeader] = req.headers[name];
     });
 


### PR DESCRIPTION
Using ' ' would only search for the first instance of a space, and then
exit. Using / /g looks for all spaces in the string and doesn't exit
after the first match.

Resolves: #14