### PR TITLE
v2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
-RUN apk add --no-cache make gcc g++ python
+RUN apk add --no-cache yarn
 WORKDIR /app
 COPY . .
-RUN npm install --loglevel=error --prod
-EXPOSE 80
-CMD [ "npm", "start" ]
+RUN yarn --frozen-lockfile --loglevel=error --prod
+EXPOSE 8080
+CMD [ "yarn", "start" ]

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 ![logo](logo.png)
 
-# Mirror HTTP Server [![Build Status](https://travis-ci.org/eexit/mirror-http-server.svg)](https://travis-ci.org/eexit/mirror-http-server) [![DockerHub](https://img.shields.io/badge/docker-hub-brightgreen.svg?style=flat)](https://hub.docker.com/r/eexit/mirror-http-server/) [![Greenkeeper badge](https://badges.greenkeeper.io/eexit/mirror-http-server.svg)](https://greenkeeper.io/)
+# Mirror HTTP Server [![Build Status](https://travis-ci.org/eexit/mirror-http-server.svg)](https://travis-ci.org/eexit/mirror-http-server) [![DockerHub](https://img.shields.io/badge/docker-hub-brightgreen.svg?style=flat)](https://hub.docker.com/r/eexit/mirror-http-server/)
 
-*A dummy HTTP server that responds whatever you told him to.*
+*A dummy HTTP server that responds whatever you told it to.*
 
-Build to play with HTTP or test your API. Make a HTTP call to the dummy server with the specified headers you want the server responds with.
+Built to play with HTTP or test your API. Make a HTTP call to the dummy server with the specified headers you want the server responds with.
 
 ## Usage
 
-Pull the [Docker](https://www.docker.com) container:
+Pull the [Docker container](https://hub.docker.com/repository/docker/eexit/mirror-http-server):
 
     docker pull eexit/mirror-http-server
 
 Start the container:
 
-    $ docker run -itp 80:80 eexit/mirror-http-server
-    2015-11-05T20:59:57.353Z]  INFO: mirror-http-server/17 on ccc867df5980: Listening on http://0.0.0.0:80
+    $ docker run -itp 8080:8080 eexit/mirror-http-server
+    2015-11-05T20:59:57.353Z]  INFO: mirror-http-server/17 on ccc867df5980: Listening on http://0.0.0.0:8080
 
 For this README examples, I use the great [HTTPie](https://github.com/jkbrzt/httpie) tool.
 
-Send request againt it:
+Send request against it:
 
-    http :80
+    http :8080
 
 ```http
 HTTP/1.1 200 OK
@@ -40,25 +40,10 @@ You can change the server response code and body by setting specific `X-Mirror-*
 ### `X-Mirror-Code`
 
 Change the server response [status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes).
-Here, simulate a server error:
 
-```bash
-time http :80 X-Mirror-Code:503 X-Mirror-Delay:2000
-HTTP/1.1 503 Service Unavailable
-Connection: keep-alive
-Content-Length: 0
-Date: Fri, 20 May 2022 09:52:04 GMT
-Keep-Alive: timeout=5
-X-Powered-By: Express
+Examples that simulates a `301` redirection and a `Content-Type` change:
 
-
-
-http :80 X-Mirror-Code:503 X-Mirror-Delay:2000  0.12s user 0.03s system 7% cpu 2.163 total
-```
-
-Here, simulates a `301` redirection and a `Content-Type` change:
-
-    http :80 \
+    http :8080 \
         X-Mirror-Code:301 \
         X-Mirror-Location:http://www.eexit.net \
         X-Mirror-Content-Type:"text/plain; charset=ISO-8859-1"
@@ -96,6 +81,25 @@ If you check the container logs:
       },
       "body": {}
     }
+```
+
+### `X-Mirror-Delay`
+
+If you need to test timeouts or errors handling like `503` HTTP responses, you can pass the
+`X-Mirror-Delay` header with a number in milliseconds before the server responds.
+
+```bash
+time http :8080 X-Mirror-Code:503 X-Mirror-Delay:2000
+HTTP/1.1 503 Service Unavailable
+Connection: keep-alive
+Content-Length: 0
+Date: Fri, 20 May 2022 09:52:04 GMT
+Keep-Alive: timeout=5
+X-Powered-By: Express
+
+
+
+http :8080 X-Mirror-Code:503 X-Mirror-Delay:2000  0.12s user 0.03s system 7% cpu 2.163 total
 ```
 
 ### `X-Mirror-Request`
@@ -171,7 +175,7 @@ X-Powered-By: Express
 
 Note: if you don't specify the `true` value for the header, it'll ignored.
 
-### Works for all headers
+### Works with any headers
 
 Aside to the previous three special headers, you can set your wanted response header by prepending your header name by `X-Mirror-`.
 

--- a/package.json
+++ b/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "mirror-http-server",
-  "version": "1.1.3",
-  "description": "A dummy HTTP server that responds whatever you told him to",
-  "scripts": {
-    "start": "node server.js | npm run bunyan",
-    "start:dev": "nodemon server.js | npm run bunyan",
-    "test": "echo \"No test specified yet\"",
-    "bunyan": "$(npm bin)/bunyan"
-  },
-  "keywords": [
-    "node",
-    "nodejs",
-    "server",
-    "http",
-    "mirror",
-    "dumb",
-    "dump",
-    "test",
-    "development"
-  ],
-  "author": "Joris Berthelot <admin@eexit.net>",
-  "license": "MIT",
-  "dependencies": {
-    "body-parser": "^1.19.0",
-    "bunyan": "^1.8.13",
-    "express": "^4.17.1",
-    "lodash": ">=4.17.20"
-  },
-  "devDependencies": {
-    "nodemon": "^2.0.0"
-  },
-  "main": "index.js",
-  "repository": "git@eexit:eexit/mirror-http-server.git"
+    "name": "mirror-http-server",
+    "version": "2.0.0",
+    "description": "A dummy HTTP server that responds whatever you told it to",
+    "scripts": {
+        "start": "node server.js | npm run bunyan",
+        "start:dev": "nodemon server.js | npm run bunyan",
+        "test": "echo \"No test specified yet\"",
+        "bunyan": "$(npm bin)/bunyan"
+    },
+    "keywords": [
+        "node",
+        "nodejs",
+        "server",
+        "http",
+        "mirror",
+        "dumb",
+        "dump",
+        "test",
+        "development"
+    ],
+    "author": "Joris Berthelot <admin@eexit.net>",
+    "license": "MIT",
+    "dependencies": {
+        "body-parser": "^1.20.0",
+        "bunyan": "^1.8.15",
+        "express": "^4.18",
+        "lodash": ">=4.17.21"
+    },
+    "devDependencies": {
+        "nodemon": "^2.0.0"
+    },
+    "main": "index.js",
+    "repository": "git@eexit:eexit/mirror-http-server.git"
 }

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const host = '0.0.0.0',
-    port = 80;
+    port = 8080;
 
 const _ = require('lodash'),
     bunyan = require('bunyan'),
@@ -61,7 +61,6 @@ app.all('*', function (req, res, next) {
     };
 
     logger.info(request);
-
 
     // Prepares the response
     res.status(mirrorCode).set(responseHeaders);

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,7 +69,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-body-parser@1.20.0, body-parser@^1.19.0:
+body-parser@1.20.0, body-parser@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
   integrity sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==
@@ -116,7 +116,7 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-bunyan@^1.8.13:
+bunyan@^1.8.15:
   version "1.8.15"
   resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
   integrity sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==
@@ -350,7 +350,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-express@^4.17.1:
+express@^4.18:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"
   integrity sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==
@@ -678,7 +678,7 @@ latest-version@^5.1.0:
   dependencies:
     package-json "^6.3.0"
 
-lodash@>=4.17.20:
+lodash@>=4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
- BC: Service is now listening on port 8080
- Updated Docker node image and install dependencies using yarn
- Updated all dependencies
- Added `X-Mirror-Delay` support
- Fixed long header name mirroring https://github.com/eexit/mirror-http-server/issues/14
- Build Docker container for linux/amd64 and linux/arm64